### PR TITLE
Only copy the output tensor to save memory usage.

### DIFF
--- a/padiff/actions.py
+++ b/padiff/actions.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .utils import compare_tensor
+from .utils import assert_tensor_equal
 import torch
 import paddle
 
@@ -76,12 +76,9 @@ class EqualAction(Action):
         torch_tensors = torch_item.compare_tensors()
         paddle_tensors = paddle_item.compare_tensors()
         for (tt,), (pt,) in zip(torch_tensors, paddle_tensors):
-            assert (
-                compare_tensor(
-                    tt.detach().numpy(),
-                    pt.numpy(),
-                    atol=atol,
-                    compare_mode=compare_mode,
-                )
-                == True
+            assert_tensor_equal(
+                tt.detach().numpy(),
+                pt.numpy(),
+                atol=atol,
+                compare_mode=compare_mode,
             )

--- a/padiff/report.py
+++ b/padiff/report.py
@@ -50,9 +50,13 @@ class ReportItem:
         """
         self.input is a tuple: (tensor, ...)
         """
-        #self.input = clone_tensors(input)
+        # self.input = clone_tensors(input)
         self.input = input
-        self.output = clone_tensors(output)
+        if self.type == 'forward': 
+            #we only clone output in forward step.
+            self.output = clone_tensors(output)
+        else: 
+            self.output = output
         self.net = net
         self.net_id = net_id
         self.fwd_item = None

--- a/padiff/report.py
+++ b/padiff/report.py
@@ -52,10 +52,10 @@ class ReportItem:
         """
         # self.input = clone_tensors(input)
         self.input = input
-        if self.type == 'forward': 
-            #we only clone output in forward step.
+        if self.type == "forward":
+            # we only clone output in forward step.
             self.output = clone_tensors(output)
-        else: 
+        else:
             self.output = output
         self.net = net
         self.net_id = net_id

--- a/padiff/report.py
+++ b/padiff/report.py
@@ -50,7 +50,8 @@ class ReportItem:
         """
         self.input is a tuple: (tensor, ...)
         """
-        self.input = clone_tensors(input)
+        #self.input = clone_tensors(input)
+        self.input = input
         self.output = clone_tensors(output)
         self.net = net
         self.net_id = net_id

--- a/padiff/utils.py
+++ b/padiff/utils.py
@@ -284,7 +284,8 @@ def log(*args):
 
 
 def compare_tensor(tensor1, tensor2, atol=1e-7, compare_mode="mean"):
-    if tensor1 is None and tensor2 is None: return True
+    if tensor1 is None and tensor2 is None:
+        return True
     if compare_mode == "strict":
         return np.allclose(tensor1, tensor2, atol=atol)
     elif compare_mode == "mean":
@@ -293,12 +294,14 @@ def compare_tensor(tensor1, tensor2, atol=1e-7, compare_mode="mean"):
     else:
         raise RuntimeError("compare_mode `{}` is not supported, use `strict` or `mean` instead".format(compare_mode))
 
+
 def assert_tensor_equal(tensor1, tensor2, atol=1e-7, compare_mode="mean"):
-    """ if equal: return None
-        else: raise Error and Error Message.
+    """if equal: return None
+    else: raise Error and Error Message.
     """
-    if tensor1 is None and tensor2 is None: return True
-    if compare_mode=='mean': 
+    if tensor1 is None and tensor2 is None:
+        return True
+    if compare_mode == "mean":
         np.testing.assert_allclose(tensor1.mean(), tensor2.mean(), atol=atol)
-    elif compare_mode=='strict': 
+    elif compare_mode == "strict":
         np.testing.assert_allclose(tensor1, tensor2, atol=atol)

--- a/padiff/utils.py
+++ b/padiff/utils.py
@@ -284,7 +284,7 @@ def log(*args):
 
 
 def compare_tensor(tensor1, tensor2, atol=1e-7, compare_mode="mean"):
-
+    if tensor1 is None and tensor2 is None: return True
     if compare_mode == "strict":
         return np.allclose(tensor1, tensor2, atol=atol)
     elif compare_mode == "mean":
@@ -292,3 +292,13 @@ def compare_tensor(tensor1, tensor2, atol=1e-7, compare_mode="mean"):
         return bool(mean_diff < atol)
     else:
         raise RuntimeError("compare_mode `{}` is not supported, use `strict` or `mean` instead".format(compare_mode))
+
+def assert_tensor_equal(tensor1, tensor2, atol=1e-7, compare_mode="mean"):
+    """ if equal: return None
+        else: raise Error and Error Message.
+    """
+    if tensor1 is None and tensor2 is None: return True
+    if compare_mode=='mean': 
+        np.testing.assert_allclose(tensor1.mean(), tensor2.mean(), atol=atol)
+    elif compare_mode=='strict': 
+        np.testing.assert_allclose(tensor1, tensor2, atol=atol)

--- a/padiff/weights.py
+++ b/padiff/weights.py
@@ -194,11 +194,12 @@ def check_weight_grad(layer, module, options):
         )
         p_param = paddle_param.numpy()
         t_param = torch_param.detach().numpy()
-        p_grad = paddle_param.grad.numpy()
-        t_grad = torch_param.grad.detach().numpy()
+        p_grad = paddle_param.grad.numpy() if paddle_param.grad is not None else None
+        t_grad = torch_param.grad.detach().numpy() if torch_param.grad is not None else None
         if settings["transpose"]:
             t_param = numpy.transpose(t_param)
-            t_grad = numpy.transpose(t_grad)
+            if t_grad is not None:
+                t_grad = numpy.transpose(t_grad)
 
         weight_log_path = os.path.join(sys.path[0], "diff_log", "weight_diff.log")
         grad_log_path = os.path.join(sys.path[0], "diff_log", "grad_diff.log")


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaDiff/pull/2 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Performance optimization
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what this PR does -->
Only copy the output tensor to save memory usage.
在大模型上，会出现内存溢出。现在只存储了输出的tensor，防止上述的问题。