### PR TITLE
Add `ignore_class` interface, which can ignore sublayers who has specific class

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,10 @@ layer_map.ignore(layer.nop_layer)
 # 此处也可以传入 Iteratable 对象（如list）
 layer_map.ignore_recursivly(layer.nop_layer)
 
+# NOPLayer是一个class name
+# 忽略layer中所有类型为 NOPLayer的sublayer
+layer_map.ignore_class(layer, NOPLayer)
+
 auto_diff(layer, module, inp, auto_weights=True, layer_map=layer_map)
 ```
 

--- a/padiff/utils.py
+++ b/padiff/utils.py
@@ -455,10 +455,12 @@ class LayerMap(object):
         self._layer_ignore_sublayer.update(set(layers))
         self._layer_ignore.update(set(layers))
 
-    def ignore_class(self, layer):
+    def ignore_class(self, layer, ign_cls=None):
         ignored = set()
+        if ign_cls == None:
+            ign_cls = self._ignore_cls
         for sublayer in self.layers(layer):
-            if isinstance(sublayer, self._ignore_cls):
+            if isinstance(sublayer, ign_cls):
                 ignored.add(sublayer)
         self._layer_ignore.update(ignored)
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaDiff/pull/2 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what this PR does -->
Add `ignore_class` interface for LayerMap
