### PR TITLE
fix bugs for import error

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
     packages=find_packages(),
     include_package_data=True,
     package_data={
-        "padiff": ["configs/assign_weight.yaml", "configs/api_mapping.json"],
+        "padiff": ["datas/assign_weight.yaml", "datas/api_mapping.json"],
     },
     python_requires=">=3.7",
     classifiers=[


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaDiff/pull/2 -->
### PR types
Bug fixes

### PR changes
Modify the setup.py

### Description
This Pull Request addresses the following bug:
After running `python setup.py install`, importing `auto_diff` from `padiff` results in the following error:
```
FileNotFoundError: [Errno 2] No such file or directory: '/root/paddlejob/workspace/work/taozewei/padiff/padiff_env/lib/python3.7/site-packages/padiff-0.3.0-py3.7.egg/padiff/datas/assign_weight.yaml'
```
The purpose of this PR is to fix the error by modifying the `setup.py` file.

Please review and merge this Pull Request when ready. Thank you!